### PR TITLE
Fix macOS casing in deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ python examples/run_basic_workflow.py
 
 AgentCore supports multiple deployment configurations optimized for different platforms:
 
-### MacOS (Apple Silicon)
+### macOS (Apple Silicon)
 - **Metal 3 Acceleration (Recommended)**
   - Optimized for Apple Silicon (M1/M2/M3/M4)
   - Automatic Metal shader optimization


### PR DESCRIPTION
## Summary
- fix capitalization for macOS in deployment configuration section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f6306ec0832eaca577f51f93799f