### PR TITLE
Fix missing os import

### DIFF
--- a/services/vector_store.py
+++ b/services/vector_store.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Dict, List, Optional, Any
 import chromadb
 from chromadb.config import Settings


### PR DESCRIPTION
## Summary
- add os import used in VectorStoreService

## Testing
- `python -m py_compile services/vector_store.py`
- `flake8 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f6b225d8832e8bcae4d1e69a1b3b